### PR TITLE
Compatible with Django 1.11 and 1.10

### DIFF
--- a/django_quicky/decorators.py
+++ b/django_quicky/decorators.py
@@ -18,6 +18,7 @@ from .utils import HttpResponseException
 __all__ = ["view", "routing"]
 
 DJANGO_GTE_17 = django.VERSION >= (1, 7)
+DJANGO_GTE_110 = django.VERSION >= (1, 10)
 
 
 def render_if(self, render_to=None, condition=lambda: False):
@@ -171,13 +172,14 @@ def routing(root=""):
     urlpatterns = UrlList()
 
     def url(regex, kwargs=None, name=None, prefix=''):
+        if prefix and DJANGO_GTE_110:
+            raise RuntimeError("Support for 'prefix' option on url() was dropped in Django 1.10. Please update your code")
 
         def decorator(func):
-
+            kwargs = {'prefix': prefix} if prefix else {}
             urlpatterns.append(
-                addurl(regex, func, kwargs, name or func.__name__, prefix),
+                addurl(regex, func, kwargs, name or func.__name__, **kwargs),
             )
-
             return func
 
         return decorator

--- a/django_quicky/decorators.py
+++ b/django_quicky/decorators.py
@@ -17,6 +17,8 @@ from .utils import HttpResponseException
 
 __all__ = ["view", "routing"]
 
+DJANGO_GTE_17 = django.VERSION[0] >= 1 and django.VERSION[1] >= 7
+
 
 def render_if(self, render_to=None, condition=lambda: False):
     """
@@ -123,7 +125,7 @@ def view(render_to=None, *args, **kwargs):
                 if rendering and not isinstance(response, HttpResponse):
 
                     if rendering == 'json':
-                        if django.VERSION[0] >= 1 and django.VERSION[1] >= 7:
+                        if DJANGO_GTE_17:
                             return HttpResponse(json.dumps(response),
                                                 content_type="application/json",
                                                 *decorator_args, **decorator_kwargs)

--- a/django_quicky/decorators.py
+++ b/django_quicky/decorators.py
@@ -17,7 +17,7 @@ from .utils import HttpResponseException
 
 __all__ = ["view", "routing"]
 
-DJANGO_GTE_17 = django.VERSION[0] >= 1 and django.VERSION[1] >= 7
+DJANGO_GTE_17 = django.VERSION >= (1, 7)
 
 
 def render_if(self, render_to=None, condition=lambda: False):

--- a/django_quicky/decorators.py
+++ b/django_quicky/decorators.py
@@ -177,8 +177,9 @@ def routing(root=""):
 
         def decorator(func):
             kwargs = {'prefix': prefix} if prefix else {}
+            final_func = func.as_view() if hasattr(func, 'as_view') else func
             urlpatterns.append(
-                addurl(regex, func, kwargs, name or func.__name__, **kwargs),
+                addurl(regex, final_func, kwargs, name or func.__name__, **kwargs),
             )
             return func
 


### PR DESCRIPTION
Conditionally raises a RuntimeError depending on the Django version and keywords provided. The new LTS (1.11) and the 1.10 are not compatible with the "prefix" keyword. 